### PR TITLE
Webpack 4 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,8 +17,8 @@ RuntimePublicPath.prototype.apply = function(compiler) {
             buf.push(source);
             buf.push('');
             buf.push('// Dynamic assets path override (webpack-runtime-public-path-plugin)');
-            buf.push(this.requireFn + '.p = (' + runtimePublicPathStr + ') || ' + this.requireFn + '.p;');
-            return this.asString(buf);
+            buf.push('__webpack_require__.p = (' + runtimePublicPathStr + ') || __webpack_require__p;');
+            return buf.join('\n');
         });
     });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-runtime-public-path-plugin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This now works with webpack v4, I couldn't find the correct new reference for `this.requireFn` so I've hardcoded it as it doesn't seem to have changed since previous versions.

Can you take a look and perhaps point me in the right direction?

Thanks

@pgroot 