### PR TITLE
Updated require extension API usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,8 @@ function buf(path, source) {
 
 RuntimePublicPath.prototype.apply = function (compiler) {
     var runtimePublicPathStr = this.options && this.options.runtimePublicPath;
+    var pluginName = this._name;
+
     if (!runtimePublicPathStr) {
         console.error('RuntimePublicPath: no output.runtimePublicPath is specified. This plugin will do nothing.');
         return;

--- a/index.js
+++ b/index.js
@@ -24,9 +24,9 @@ RuntimePublicPath.prototype.apply = function (compiler) {
     }
 
     if (compiler.hooks && compiler.hooks.thisCompilation) {
-        compiler.hooks.thisCompilation.tap(this._name, function (compilation) {
-            compilation.mainTemplate.plugin('require-extensions', function (source, chunk, hash) {
-                return buf(runtimePublicPathStr, source)
+        compiler.hooks.compilation.tap(pluginName, function (compilation) {
+            compilation.mainTemplate.hooks.requireExtensions.tap(pluginName, function(source) {
+                return buf(runtimePublicPathStr, source);
             });
         });
     } else {


### PR DESCRIPTION
We're still getting a deprecation warning when running this plugin on Webpack 4:

`DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead`

I've updated the usage within `if(compiler.hooks) {...` to use the correct API for `requireExtensions`.